### PR TITLE
Strip any leading /

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -81,7 +81,7 @@ class Lambda extends RequestStreamHandler {
   }
 
   private def childrenOfFolder(asset: DynamoTable, tableName: String, gsiName: String): IO[List[DynamoTable]] = {
-    val childrenParentPath = s"${asset.parentPath}/${asset.id}"
+    val childrenParentPath = s"${asset.parentPath}/${asset.id}".stripPrefix("/")
     dynamoClient
       .queryItems[DynamoTable](tableName, gsiName, "batchId" === asset.batchId and "parentPath" === childrenParentPath)
   }

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -213,6 +213,21 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     serveEvents.head.getRequest.getBodyAsString should equal(s"""{"RequestItems":{"test-table":{"Keys":[{"id":{"S":"$folderId"}}]}}}""")
   }
 
+  "handleRequest" should "pass the parent path with no prefixed slash to dynamo if the parent path is empty" in {
+    stubGetRequest(dynamoGetResponse.replace("a/parent/path", ""))
+    stubQueryRequest(emptyDynamoQueryResponse)
+    intercept[Exception] {
+      TestLambda().handleRequest(standardInput, outputStream, null)
+    }
+    val serveEvents = dynamoServer.getAllServeEvents.asScala
+    val queryEvent = serveEvents.head
+    val requestBody = queryEvent.getRequest.getBodyAsString
+    val expectedRequestBody =
+      """{"TableName":"test-table","IndexName":"test-gsi","KeyConditionExpression":"#A = :batchId AND #B = :parentPath",""" +
+        s""""ExpressionAttributeNames":{"#A":"batchId","#B":"parentPath"},"ExpressionAttributeValues":{":batchId":{"S":"TEST-ID"},":parentPath":{"S":"68b1c80b-36b8-4f0f-94d6-92589002d87e"}}}"""
+    expectedRequestBody should equal(requestBody)
+  }
+
   "handleRequest" should "pass the correct parameters to dynamo for the query request" in {
     stubGetRequest(dynamoGetResponse)
     stubQueryRequest(emptyDynamoQueryResponse)

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -224,7 +224,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     val requestBody = queryEvent.getRequest.getBodyAsString
     val expectedRequestBody =
       """{"TableName":"test-table","IndexName":"test-gsi","KeyConditionExpression":"#A = :batchId AND #B = :parentPath",""" +
-        s""""ExpressionAttributeNames":{"#A":"batchId","#B":"parentPath"},"ExpressionAttributeValues":{":batchId":{"S":"TEST-ID"},":parentPath":{"S":"68b1c80b-36b8-4f0f-94d6-92589002d87e"}}}"""
+        s""""ExpressionAttributeNames":{"#A":"batchId","#B":"parentPath"},"ExpressionAttributeValues":{":batchId":{"S":"TEST-ID"},":parentPath":{"S":"$folderId"}}}"""
     expectedRequestBody should equal(requestBody)
   }
 


### PR DESCRIPTION
If the parentPath is empty, you end up with a leading / but the parent
paths in dynamo don't have one. This removes it

I've added a test to check for it.
