### PR TITLE
DR2-1383 Use new dynamo formatter classes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,9 +12,8 @@ object Dependencies {
   lazy val scalaXml = "org.scala-lang.modules" %% "scala-xml" % "2.2.0"
   lazy val upickle = "com.lihaoyi" %% "upickle" % "3.1.3"
   lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % "0.1.27"
-  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.3"
+  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.5"
   lazy val s3Client = "uk.gov.nationalarchives" %% "da-s3-client" % "0.1.27"
-
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.17"
   lazy val wiremock = "com.github.tomakehurst" % "wiremock" % "3.0.1"
 }

--- a/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -6,6 +6,7 @@ import cats.implicits._
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import fs2.Stream
 import fs2.interop.reactivestreams._
+import org.scanamo.{DynamoFormat, DynamoReadError, DynamoValue, MissingProperty, TypeCoercionError}
 import org.scanamo.syntax._
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
@@ -18,6 +19,7 @@ import upickle.default._
 
 import java.io.{InputStream, OutputStream}
 import java.util.UUID
+import scala.jdk.CollectionConverters.MapHasAsScala
 
 class Lambda extends RequestStreamHandler {
 
@@ -25,26 +27,47 @@ class Lambda extends RequestStreamHandler {
   val dynamoClient: DADynamoDBClient[IO] = DADynamoDBClient[IO]()
   val s3Client: DAS3Client[IO] = DAS3Client[IO]()
 
+  private def toFolderOrAssetTable[T <: DynamoTable](dynamoValue: DynamoValue)(implicit dynamoFormat: DynamoFormat[T]): Either[DynamoReadError, FolderOrAssetTable] =
+    dynamoFormat.read(dynamoValue).map { table =>
+      FolderOrAssetTable(table.batchId, table.id, table.parentPath, table.name, table.`type`, table.title, table.description, table.identifiers)
+    }
+
+  implicit val folderOrAssetFormat: DynamoFormat[FolderOrAssetTable] = new DynamoFormat[FolderOrAssetTable] {
+    override def read(dynamoValue: DynamoValue): Either[DynamoReadError, FolderOrAssetTable] =
+      dynamoValue.toAttributeValue.m().asScala.toMap.get("type").map(_.s()) match {
+        case Some(rowType) =>
+          rowType match {
+            case "Asset"                           => toFolderOrAssetTable[AssetDynamoTable](dynamoValue)
+            case "ArchiveFolder" | "ContentFolder" => toFolderOrAssetTable[ArchiveFolderDynamoTable](dynamoValue)
+            case _                                 => Left(TypeCoercionError(new RuntimeException("Row is not an 'Asset' or a 'File'")))
+          }
+        case None => Left[DynamoReadError, FolderOrAssetTable](MissingProperty)
+      }
+
+    // We're not using write but we have to have this overridden
+    override def write(t: FolderOrAssetTable): DynamoValue = DynamoValue.nil
+  }
+
   override def handleRequest(inputStream: InputStream, output: OutputStream, context: Context): Unit = {
     val inputString = inputStream.readAllBytes().map(_.toChar).mkString
     val input = read[Input](inputString)
     for {
       config <- ConfigSource.default.loadF[IO, Config]()
-      folderItems <- dynamoClient.getItems[DynamoTable, PartitionKey](List(PartitionKey(input.id)), config.dynamoTableName)
+      folderItems <- dynamoClient.getItems[ArchiveFolderDynamoTable, PartitionKey](List(PartitionKey(input.id)), config.dynamoTableName)
       folder <- IO.fromOption(folderItems.headOption)(
         new Exception(s"No folder found for ${input.id} and ${input.batchId}")
       )
-      _ <- if (!isFolder(folder)) IO.raiseError(new Exception(s"Object ${folder.id} is of type ${folder.`type`} and not 'ContentFolder' or 'ArchiveFolder'")) else IO.unit
+      _ <- if (!isFolder(folder.`type`)) IO.raiseError(new Exception(s"Object ${folder.id} is of type ${folder.`type`} and not 'ContentFolder' or 'ArchiveFolder'")) else IO.unit
       children <- childrenOfFolder(folder, config.dynamoTableName, config.dynamoGsiName)
       _ <- IO.fromOption(children.headOption)(new Exception(s"No children found for ${input.id} and ${input.batchId}"))
       assetRows <- getAssetRowsWithFileSize(children, config.bucketName, input.executionName)
-      folderRows <- IO(children.filter(isFolder))
+      folderRows <- IO(children.filter(child => isFolder(child.`type`)))
       folderOpex <- xmlCreator.createFolderOpex(folder, assetRows, folderRows, folder.identifiers)
       _ <- uploadXMLToS3(folderOpex, config.bucketName, generateKey(input.executionName, folder))
     } yield ()
   }.unsafeRunSync()
 
-  private def isFolder(table: DynamoTable) = List(ContentFolder, ArchiveFolder).contains(table.`type`)
+  private def isFolder(rowType: Type) = List(ContentFolder, ArchiveFolder).contains(rowType)
 
   private def generateKey(executionName: String, folder: DynamoTable) =
     s"opex/$executionName/${formatParentPath(folder.parentPath)}${folder.id}/${folder.id}.opex"
@@ -56,22 +79,22 @@ class Lambda extends RequestStreamHandler {
       s3Client.upload(destinationBucket, key, xmlString.getBytes.length, publisher)
     }
 
-  private def getAssetRowsWithFileSize(children: List[DynamoTable], bucketName: String, executionName: String): IO[List[DynamoTable]] = {
+  private def getAssetRowsWithFileSize(children: List[FolderOrAssetTable], bucketName: String, executionName: String): IO[List[AssetOrFileWithFileSize]] = {
     children
       .filter(_.`type` == Asset)
       .map { asset =>
         val key = s"opex/$executionName/${formatParentPath(asset.parentPath)}${asset.id}.pax.opex"
         s3Client
           .headObject(bucketName, key)
-          .map(headResponse => asset.copy(fileSize = Option(headResponse.contentLength())))
+          .map(headResponse => AssetOrFileWithFileSize(asset, headResponse.contentLength()))
       }
       .sequence
   }
 
-  private def childrenOfFolder(asset: DynamoTable, tableName: String, gsiName: String): IO[List[DynamoTable]] = {
+  private def childrenOfFolder(asset: ArchiveFolderDynamoTable, tableName: String, gsiName: String): IO[List[FolderOrAssetTable]] = {
     val childrenParentPath = s"${asset.parentPath.getOrElse("")}/${asset.id}".stripPrefix("/")
     dynamoClient
-      .queryItems[DynamoTable](tableName, gsiName, "batchId" === asset.batchId and "parentPath" === childrenParentPath)
+      .queryItems[FolderOrAssetTable](tableName, gsiName, "batchId" === asset.batchId and "parentPath" === childrenParentPath)
   }
 }
 
@@ -81,5 +104,18 @@ object Lambda {
   private case class Config(dynamoTableName: String, bucketName: String, dynamoGsiName: String)
 
   case class Input(id: UUID, batchId: String, executionName: String)
+
+  case class AssetOrFileWithFileSize(asset: FolderOrAssetTable, fileSize: Long)
+
+  case class FolderOrAssetTable(
+      batchId: String,
+      id: UUID,
+      parentPath: Option[String],
+      name: String,
+      `type`: Type,
+      title: Option[String],
+      description: Option[String],
+      identifiers: List[Identifier]
+  )
 
 }

--- a/src/main/scala/uk/gov/nationalarchives/XMLCreator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/XMLCreator.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives
 
 import cats.effect.IO
 import uk.gov.nationalarchives.DynamoFormatters._
-import uk.gov.nationalarchives.Lambda.{FolderOrAssetTable, AssetOrFileWithFileSize}
+import uk.gov.nationalarchives.Lambda.{FolderOrAssetTable, AssetWithFileSize}
 
 import scala.xml.PrettyPrinter
 
@@ -11,7 +11,7 @@ class XMLCreator {
 
   def createFolderOpex(
       folder: ArchiveFolderDynamoTable,
-      childAssets: List[AssetOrFileWithFileSize],
+      childAssets: List[AssetWithFileSize],
       childFolders: List[FolderOrAssetTable],
       identifiers: List[Identifier],
       securityDescriptor: String = "open"

--- a/src/main/scala/uk/gov/nationalarchives/XMLCreator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/XMLCreator.scala
@@ -2,6 +2,7 @@ package uk.gov.nationalarchives
 
 import cats.effect.IO
 import uk.gov.nationalarchives.DynamoFormatters._
+import uk.gov.nationalarchives.Lambda.{FolderOrAssetTable, AssetOrFileWithFileSize}
 
 import scala.xml.PrettyPrinter
 
@@ -9,9 +10,9 @@ class XMLCreator {
   private val opexNamespace = "http://www.openpreservationexchange.org/opex/v1.2"
 
   def createFolderOpex(
-      folder: DynamoTable,
-      childAssets: List[DynamoTable],
-      childFolders: List[DynamoTable],
+      folder: ArchiveFolderDynamoTable,
+      childAssets: List[AssetOrFileWithFileSize],
+      childFolders: List[FolderOrAssetTable],
       identifiers: List[Identifier],
       securityDescriptor: String = "open"
   ): IO[String] = IO {
@@ -34,11 +35,11 @@ class XMLCreator {
         {if (isHierarchyFolder) <opex:SourceID>{folder.name}</opex:SourceID>}
         <opex:Manifest>
           <opex:Folders>
-            {childAssets.map(asset => <opex:Folder>{asset.id}.pax</opex:Folder>)}
+            {childAssets.map(assetWithFileSize => <opex:Folder>{assetWithFileSize.asset.id}.pax</opex:Folder>)}
             {childFolders.map(folder => <opex:Folder>{folder.id}</opex:Folder>)}
           </opex:Folders>
           <opex:Files>
-            {childAssets.map(asset => <opex:File type="metadata" size={asset.fileSize.getOrElse(0).toString}>{asset.id.toString}.pax.opex</opex:File>)}
+            {childAssets.map(assetWithFileSize => <opex:File type="metadata" size={assetWithFileSize.fileSize.toString}>{assetWithFileSize.asset.id.toString}.pax.opex</opex:File>)}
           </opex:Files>
         </opex:Manifest>
       </opex:Transfer>

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -52,14 +52,14 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     }
   }
 
-  def stubGetRequest(batchGetResponse: String): Unit =
+  def stubBatchGetRequest(batchGetResponse: String): Unit =
     dynamoServer.stubFor(
       post(urlEqualTo("/"))
         .withRequestBody(matchingJsonPath("$.RequestItems", containing("test-table")))
         .willReturn(ok().withBody(batchGetResponse))
     )
 
-  def stubQueryRequest(queryResponse: String): Unit =
+  def stubDynamoQueryRequest(queryResponse: String): Unit =
     dynamoServer.stubFor(
       post(urlEqualTo("/"))
         .withRequestBody(matchingJsonPath("$.TableName", equalTo("test-table")))
@@ -201,7 +201,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "return an error if the folder is not found in dynamo" in {
-    stubGetRequest(emptyDynamoGetResponse)
+    stubBatchGetRequest(emptyDynamoGetResponse)
     val ex = intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }
@@ -209,8 +209,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "return an error if no children are found for the folder" in {
-    stubGetRequest(dynamoGetResponse)
-    stubQueryRequest(emptyDynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse)
+    stubDynamoQueryRequest(emptyDynamoQueryResponse)
     val ex = intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }
@@ -218,8 +218,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "return an error if the dynamo entry does not have a type of 'folder'" in {
-    stubGetRequest(dynamoGetResponse.replace("ArchiveFolder", "Asset"))
-    stubQueryRequest(emptyDynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse.replace("ArchiveFolder", "Asset"))
+    stubDynamoQueryRequest(emptyDynamoQueryResponse)
     val ex = intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }
@@ -227,7 +227,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "pass the correct id to dynamo getItem" in {
-    stubGetRequest(emptyDynamoGetResponse)
+    stubBatchGetRequest(emptyDynamoGetResponse)
     intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }
@@ -237,8 +237,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "pass the parent path with no prefixed slash to dynamo if the parent path is empty" in {
-    stubGetRequest(dynamoGetResponse.replace("a/parent/path", ""))
-    stubQueryRequest(emptyDynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse.replace("a/parent/path", ""))
+    stubDynamoQueryRequest(emptyDynamoQueryResponse)
     intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }
@@ -252,8 +252,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "pass the correct parameters to dynamo for the query request" in {
-    stubGetRequest(dynamoGetResponse)
-    stubQueryRequest(emptyDynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse)
+    stubDynamoQueryRequest(emptyDynamoQueryResponse)
     intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }
@@ -267,8 +267,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   }
 
   "handleRequest" should "upload the opex file to the correct path" in {
-    stubGetRequest(dynamoGetResponse)
-    stubQueryRequest(dynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse)
+    stubDynamoQueryRequest(dynamoQueryResponse)
     val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
     stubPutRequest(opexPath)
 
@@ -303,8 +303,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
           </opex:Manifest>
         </opex:Transfer>
       </opex:OPEXMetadata>
-    stubGetRequest(dynamoGetResponse)
-    stubQueryRequest(dynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse)
+    stubDynamoQueryRequest(dynamoQueryResponse)
     val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
     stubPutRequest(opexPath)
 
@@ -327,8 +327,8 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
 
   "handleRequest" should "return an error if the S3 API is unavailable" in {
     s3Server.stop()
-    stubGetRequest(dynamoGetResponse)
-    stubQueryRequest(dynamoQueryResponse)
+    stubBatchGetRequest(dynamoGetResponse)
+    stubDynamoQueryRequest(dynamoQueryResponse)
     val ex = intercept[Exception] {
       TestLambda().handleRequest(standardInput, outputStream, null)
     }

--- a/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -85,15 +85,6 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |  "Count": 2,
        |  "Items": [
        |    {
-       |      "checksumSha256": {
-       |        "S": "checksum"
-       |      },
-       |      "fileExtension": {
-       |        "S": "json"
-       |      },
-       |      "fileSize": {
-       |        "N": "1"
-       |      },
        |      "id": {
        |        "S": "$childId"
        |      },
@@ -104,7 +95,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |        "S": "$batchId.json"
        |      },
        |      "type": {
-       |        "S": "ArchiveFolder"
+       |        "S": "ContentFolder"
        |      },
        |      "batchId": {
        |        "S": "$batchId"
@@ -125,6 +116,35 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |      },
        |      "batchId": {
        |        "S": "$batchId"
+       |      },
+       |      "transferringBody": {
+       |        "S": "transferringBody"
+       |      },
+       |      "transferCompleteDatetime": {
+       |        "S": "2023-12-07T17:22:23.605036797Z"
+       |      },
+       |      "upstreamSystem": {
+       |        "S": "upstreamSystem"
+       |      },
+       |      "digitalAssetSource": {
+       |        "S": "digitalAssetSource"
+       |      },
+       |      "digitalAssetSubtype": {
+       |        "S": "digitalAssetSubtype"
+       |      },
+       |      "originalFiles": {
+       |        "L": [
+       |        {
+       |          "S": "${UUID.randomUUID()}"
+       |        }
+       |       ]
+       |      },
+       |      "originalMetadataFiles": {
+       |        "L": [
+       |          {
+       |            "S": "${UUID.randomUUID()}"
+       |          }
+       |        ]
        |      }
        |    }
        |]

--- a/src/test/scala/uk/gov/nationalarchives/XMLCreatorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/XMLCreatorTest.scala
@@ -4,6 +4,7 @@ import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import uk.gov.nationalarchives.DynamoFormatters._
+import uk.gov.nationalarchives.Lambda.{FolderOrAssetTable, AssetOrFileWithFileSize}
 
 import java.util.UUID
 import scala.xml.{Elem, PrettyPrinter}
@@ -104,7 +105,7 @@ class XMLCreatorTest extends AnyFlatSpec {
     </opex:Transfer>
   </opex:OPEXMetadata>
 
-  val folder: DynamoTable = DynamoTable(
+  val folder: ArchiveFolderDynamoTable = ArchiveFolderDynamoTable(
     "TEST-ID",
     UUID.fromString("90730c77-8faa-4dbf-b20d-bba1046dac87"),
     Option("parentPath"),
@@ -112,31 +113,28 @@ class XMLCreatorTest extends AnyFlatSpec {
     ArchiveFolder,
     Option("title"),
     Option("description"),
-    Option(1),
-    Option(1),
-    Option("checksum"),
-    Option("ext")
+    Nil
   )
   val assetUuids: List[UUID] = List(UUID.fromString("a814ee41-89f4-4975-8f92-303553fe9a02"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
   val folderUuids: List[UUID] = List(UUID.fromString("7fcd94a9-be3f-456d-875f-bc697f7ed106"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
-  val childAssets: List[DynamoTable] = assetUuids.zipWithIndex.map { case (uuid, suffix) =>
-    DynamoTable(
-      "TEST-ID",
-      uuid,
-      Option(s"parentPath$suffix"),
-      s"name$suffix Asset",
-      Asset,
-      Option(s"title$suffix Asset"),
-      Option(s"description$suffix Asset"),
-      Option(1),
-      Option(1),
-      Option(s"checksum$suffix Asset"),
-      Option(s"ext$suffix")
+  val childAssets: List[AssetOrFileWithFileSize] = assetUuids.zipWithIndex.map { case (uuid, suffix) =>
+    AssetOrFileWithFileSize(
+      FolderOrAssetTable(
+        "TEST-ID",
+        uuid,
+        Option(s"parentPath$suffix"),
+        s"name$suffix Asset",
+        Asset,
+        Option(s"title$suffix Asset"),
+        Option(s"description$suffix Asset"),
+        Nil
+      ),
+      1
     )
   }
 
-  val childFolders: List[DynamoTable] = folderUuids.zipWithIndex.map { case (uuid, suffix) =>
-    DynamoTable(
+  val childFolders: List[FolderOrAssetTable] = folderUuids.zipWithIndex.map { case (uuid, suffix) =>
+    FolderOrAssetTable(
       "TEST-ID",
       uuid,
       Option(s"parentPath$suffix"),
@@ -144,10 +142,7 @@ class XMLCreatorTest extends AnyFlatSpec {
       ContentFolder,
       Option(s"title$suffix Folder"),
       Option(s"description$suffix Folder"),
-      Option(1),
-      Option(1),
-      Option(s"checksum$suffix Folder"),
-      Option(s"ext$suffix")
+      Nil
     )
   }
 

--- a/src/test/scala/uk/gov/nationalarchives/XMLCreatorTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/XMLCreatorTest.scala
@@ -4,7 +4,7 @@ import cats.effect.unsafe.implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import uk.gov.nationalarchives.DynamoFormatters._
-import uk.gov.nationalarchives.Lambda.{FolderOrAssetTable, AssetOrFileWithFileSize}
+import uk.gov.nationalarchives.Lambda.{FolderOrAssetTable, AssetWithFileSize}
 
 import java.util.UUID
 import scala.xml.{Elem, PrettyPrinter}
@@ -105,7 +105,7 @@ class XMLCreatorTest extends AnyFlatSpec {
     </opex:Transfer>
   </opex:OPEXMetadata>
 
-  val folder: ArchiveFolderDynamoTable = ArchiveFolderDynamoTable(
+  val archiveFolder: ArchiveFolderDynamoTable = ArchiveFolderDynamoTable(
     "TEST-ID",
     UUID.fromString("90730c77-8faa-4dbf-b20d-bba1046dac87"),
     Option("parentPath"),
@@ -117,8 +117,8 @@ class XMLCreatorTest extends AnyFlatSpec {
   )
   val assetUuids: List[UUID] = List(UUID.fromString("a814ee41-89f4-4975-8f92-303553fe9a02"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
   val folderUuids: List[UUID] = List(UUID.fromString("7fcd94a9-be3f-456d-875f-bc697f7ed106"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
-  val childAssets: List[AssetOrFileWithFileSize] = assetUuids.zipWithIndex.map { case (uuid, suffix) =>
-    AssetOrFileWithFileSize(
+  val childAssets: List[AssetWithFileSize] = assetUuids.zipWithIndex.map { case (uuid, suffix) =>
+    AssetWithFileSize(
       FolderOrAssetTable(
         "TEST-ID",
         uuid,
@@ -149,17 +149,17 @@ class XMLCreatorTest extends AnyFlatSpec {
   private val prettyPrinter = new PrettyPrinter(200, 2)
 
   "createFolderOpex" should "create the correct opex xml, excluding the SourceId, if folder type is not 'ArchiveFolder' and there are no identifiers" in {
-    val xml = XMLCreator().createFolderOpex(folder.copy(`type` = ContentFolder), childAssets, childFolders, Nil).unsafeRunSync()
+    val xml = XMLCreator().createFolderOpex(archiveFolder.copy(`type` = ContentFolder), childAssets, childFolders, Nil).unsafeRunSync()
     xml should equal(prettyPrinter.format(expectedStandardNonArchiveFolderXml))
   }
 
   "createFolderOpex" should "create the correct opex xml, including the SourceId, if folder type is 'ArchiveFolder' and there are identifiers" in {
-    val xml = XMLCreator().createFolderOpex(folder, childAssets, childFolders, List(Identifier("Code", "name"))).unsafeRunSync()
+    val xml = XMLCreator().createFolderOpex(archiveFolder, childAssets, childFolders, List(Identifier("Code", "name"))).unsafeRunSync()
     xml should equal(prettyPrinter.format(expectedStandardArchivedFolderXml))
   }
 
   "createFolderOpex" should "create the correct opex xml, using the name if the title is blank" in {
-    val xml = XMLCreator().createFolderOpex(folder.copy(title = None), childAssets, childFolders, Nil).unsafeRunSync()
+    val xml = XMLCreator().createFolderOpex(archiveFolder.copy(title = None), childAssets, childFolders, Nil).unsafeRunSync()
     xml should equal(prettyPrinter.format(expectedXmlNoTitle))
   }
 }


### PR DESCRIPTION
Because the validation we do against the dynamo classes depends on the
type of row, we've split out the formatters into different classes.

The problem here is that the children can be either folders or assets.
I've added a couple of custom case classes and a custom formatter which
will return the necessary fields from the asset or folder.

The validation for the asset will still happen, even though we aren't
using some of the validated fields.

The rest of the changes are updating the tests to add fields to the test
responses that are now mandatory
